### PR TITLE
enable travis and automatic snapshot publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+sudo: required
+dist: trusty
+jdk:
+- openjdk8
+after_success:
+- if [[ $TRAVIS_BRANCH == master ]]; then ./gradlew uploadArchives; fi
+# if this is actually a commit to master and not a pull request build into master, then publish master-snapshot
+- if [[ $TRAVIS_BRANCH == master && $TRAVIS_PULL_REQUEST == false ]]; then
+    git tag master;
+    ./gradlew uploadArchives;
+  fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # gatk-native-bindings
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.broadinstitute/gatk-native-bindings/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.broadinstitute/gatk-native-bindings)
+[![Build Status](https://travis-ci.org/broadinstitute/gatk-native-bindings.svg?branch=master)](https://travis-ci.org/broadinstitute/gatk-native-bindings)


### PR DESCRIPTION
adding a trivial travis build that checks that the project compiles and then publishes snapshots
adding a travis badge to the README